### PR TITLE
Fix missing scale and orientation in cached SIFT features

### DIFF
--- a/wildlife_tools/features/local.py
+++ b/wildlife_tools/features/local.py
@@ -47,12 +47,23 @@ class GlueFactoryExtractor(FeatureCacheMixin):
         self.model = get_model(config.name)(config)
 
     def _save_entry(self, txn: lmdb.Transaction, key: bytes, entry) -> None:
-        entry = {
-            "keypoints": entry["keypoints"].clone().cpu(),
-            "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
-            "descriptors": entry["descriptors"].clone().cpu(),
-            "image_size": entry["image_size"].clone().cpu(),
-        }
+        if "scales" in entry and "oris" in entry:
+            entry = {
+                "keypoints": entry["keypoints"].clone().cpu(),
+                "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
+                "descriptors": entry["descriptors"].clone().cpu(),
+                "scales": entry["scales"].clone().cpu(),
+                "oris": entry["oris"].clone().cpu(),
+                "image_size": entry["image_size"].clone().cpu(),
+            }
+        else:
+            entry = {
+                "keypoints": entry["keypoints"].clone().cpu(),
+                "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
+                "descriptors": entry["descriptors"].clone().cpu(),
+                "image_size": entry["image_size"].clone().cpu(),
+            }
+        
         super()._save_entry(txn, key, entry)
 
     def cat_features_dictionary(self, feats: list[dict]) -> list[dict]:

--- a/wildlife_tools/features/local.py
+++ b/wildlife_tools/features/local.py
@@ -47,24 +47,16 @@ class GlueFactoryExtractor(FeatureCacheMixin):
         self.model = get_model(config.name)(config)
 
     def _save_entry(self, txn: lmdb.Transaction, key: bytes, entry) -> None:
-        if "scales" in entry and "oris" in entry:
-            entry = {
-                "keypoints": entry["keypoints"].clone().cpu(),
-                "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
-                "descriptors": entry["descriptors"].clone().cpu(),
-                "scales": entry["scales"].clone().cpu(),
-                "oris": entry["oris"].clone().cpu(),
-                "image_size": entry["image_size"].clone().cpu(),
-            }
-        else:
-            entry = {
-                "keypoints": entry["keypoints"].clone().cpu(),
-                "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
-                "descriptors": entry["descriptors"].clone().cpu(),
-                "image_size": entry["image_size"].clone().cpu(),
-            }
-        
+        entry = self._extract_entry(entry)
         super()._save_entry(txn, key, entry)
+
+    def _extract_entry(self, entry):
+        return {
+            "keypoints": entry["keypoints"].clone().cpu(),
+            "keypoint_scores": entry["keypoint_scores"].clone().cpu(),
+            "descriptors": entry["descriptors"].clone().cpu(),
+            "image_size": entry["image_size"].clone().cpu(),
+        }
 
     def cat_features_dictionary(self, feats: list[dict]) -> list[dict]:
         return feats
@@ -188,3 +180,9 @@ class SiftExtractor(GlueFactoryExtractor):
 
         # Fix extract_single_image method.
         self.model.extract_single_image = types.MethodType(extract_single_image_fix, self.model)
+
+    def _extract_entry(self, entry):
+        entry_new = super()._extract_entry(entry)
+        entry_new["scales"] = entry["scales"].clone().cpu()
+        entry_new["oris"] = entry["oris"].clone().cpu()
+        return entry_new


### PR DESCRIPTION
## :memo: What does this PR do ?
Check for `scales` and `oris` keys in datapoints and writes cache accordingly if they are present.

### :small_blue_diamond: Current behavior

- SIFT features retrieved from the cache miss `scales` and `oris` keys. Thus, a key error occurs in the [LightGlue library](https://github.com/cvg/LightGlue/blob/eb42fee2d71449efb0aa5c10549752b5d75384d8/lightglue/lightglue.py#L501).

### :small_orange_diamond: New behavior
- The features are saved and retrieved with `scales` and `oris`. LightGlue forward function executes normally.

### :warning: Potential breaks
- Assumes that `scales` and `oris` should always occur together, does not check for the presence of `scales` and `oris` independently.

## :white_check_mark: Checklist
Before submitting, please make sure you check the following:

- [X] Lint and tests pass locally with my changes
- [ ] I've added the necessary documentation
